### PR TITLE
Dealing with corner cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 # Ignore idea stuff
 .idea
 out
+
+.kotlintest

--- a/src/main/resources/source.pt
+++ b/src/main/resources/source.pt
@@ -300,7 +300,7 @@ public def zero() {
 
 /**
  * Aggregation of local information.
- * 
+ *
  * @param local  T, local information
  * @param reduce (T, T) -> T, how to aggregate information
  */
@@ -361,7 +361,7 @@ public def C(potential, reduce, local, null) {
                 (a, b) -> { reduce.apply(a, b) },
                 // expression that will be evaluated if the field is empty
                 null,
-                mux (nbr(getParent(potential, x -> { x.getDeviceUID() })) == self.getDeviceUID()) { 
+                mux (nbr(getParent(potential, x -> { x.getDeviceUID() })) == self.getDeviceUID()) {
                     v
                 } else { null }
             )
@@ -480,7 +480,7 @@ public def cossip(sink, value, f) {
 
 /**
  * Count the devices.
- * 
+ *
  * @param potential num, gradient of which gives aggregation direction
  * @return          num, number of devices
  */
@@ -490,7 +490,7 @@ public def countDevices(potential) {
 
 /**
  * Count the devices in a region.
- * 
+ *
  * @param potential num, gradient of which gives aggregation direction
  * @param condition bool, device discriminant
  * @param region    bool, region discriminant
@@ -502,7 +502,7 @@ public def countDevicesInRegion(potential, condition, region) {
 
 /**
  * Count the devices with a given condition.
- * 
+ *
  * @param potential num, gradient of which gives aggregation direction
  * @param condition bool, discriminant
  * @return          num, number of devices
@@ -512,7 +512,7 @@ public def countDevicesWithCondition(potential, condition) {
 }
 
 /**
- * Gossip and estimate the diameter of the connected component joined by 
+ * Gossip and estimate the diameter of the connected component joined by
  * the current device.
  *
  * @param source    bool, source of the connected component
@@ -523,7 +523,7 @@ public def diameter(source) {
 }
 
 /**
- * Gossip and estimate the diameter of the connected component joined by 
+ * Gossip and estimate the diameter of the connected component joined by
  * the current device.
  *
  * @param source    bool, source of the connected component
@@ -538,7 +538,7 @@ public def diameterWithMetric(source, metric) {
 }
 
 /**
- * Gossip and estimate the diameter of the connected component joined by 
+ * Gossip and estimate the diameter of the connected component joined by
  * the current device.
  *
  * @param source    bool, source of the connected component
@@ -549,7 +549,7 @@ public def diameterInRegion(source, region) {
 }
 
 /**
- * Gossip and estimate the diameter of the connected component joined by 
+ * Gossip and estimate the diameter of the connected component joined by
  * the current device.
  *
  * @param source    bool, source of the connected component
@@ -614,264 +614,4 @@ public def getChildren(potential, f, g, default) {
         g,
         default
     )
-}
-
-/**
- * Apply function to the children of the current device. A child may have multiple parents.
- *
- * @param potential num, potential to be followed
- * @param condition () -> bool, which children should be considered
- * @param f         (ExecutionContext) -> T', function to be applied to the child
- * @param g         (T) -> T, function to be applied to the child value
- * @param default   T, default value for devices which are not children
- * @return          [num|T', T], children list
- */
-public def getChildrenExtended(potential, condition, f, g, default) {
-    mux (condition.apply()) {
-        nbr([f.apply(self), g.apply()])
-    } else {
-        [noParent(), default]
-    }
-}
-
-/**
- * Get the ids of all the children of the current device.
- *
- * @param potential num, potential to be followed
- * @return          [num], list of children ids
- */
-public def getChildrenIds(potential) {
-    idUnion(
-        getChildren(
-            potential,
-            (device) -> { device.getDeviceUID() },
-            () -> { NaN },
-            NaN
-        ).get(0)
-    )
-}
-
-/**
- * Find the parent of the current device following the maximum decrease in
- * potential.
- *
- * @param potential num, potential
- * @param f         (ExecutionContext) -> T, what to do with the parent
- * @return          num|T, imRoot()|noParent()|f(parent)
- * @see imRoot, noParent
- */
-public def getParent(potential, f) {
-    getParentExtended(potential, f, value -> { NaN }, NaN).get(0)
-}
-
-/**
- * Find the parent of the current device following the maximum decrease in
- * potential.
- *
- * @param potential num, potential
- * @param f         (ExecutionContext) -> T, what to do with the parent
- * @param g         (T') -> T', what to do with the value
- * @param local     T', local value
- * @return          [num|T,T'], [imRoot()|noParent()|f(parent), g(value)]
- * @see imRoot, noParent
- */
-public def getParentExtended(potential, f, g, local) {
-    getParentsExtended(potential, v -> { minHood(v) }, f, g, local, local)
-}
-
-/**
- * Find the parents of the current device following the decrease in
- * potential.
- *
- * @param potential num, potential
- * @param f         (ExecutionContext) -> T, what to do with the parent
- * @param g         (T') -> T', what to do with the value
- * @param local     T', local value
- * @return          [[num|T,T']], [[imRoot()|noParent()|f(parent), g(value)]]
- * @see imRoot, noParent
- */
-public def getParents(potential, f, g, local, default) {
-    getParentsExtended(potential, identity, f, g, local, default)
-}
-
-
-/**
- * Find the parents of the current device following the decrease in
- * potential.
- *
- * @param potential num, potential
- * @param condition (num) -> bool, how to determine parent devices
- * @param f         (ExecutionContext) -> T, what to do with the parent
- * @param g         (T') -> T', what to do with the value
- * @param local     T', local value
- * @return          [[num|T,T']], [[imRoot()|noParent()|f(parent), g(value)]]
- * @see imRoot, noParent
- */
-public def getParentsExtended(potential, condition, f, g, local, default) {
-    mux (condition.apply(nbr(potential)) < potential) {
-        let c = condition.apply(nbr([potential, f.apply(self), g.apply(local)]));
-        mux (c.size() > 1) {  [c.get(1), c.get(2)] }
-        else { [noParent(), default] }
-    } else { [imRoot(), default] }
-}
-
-/**
- * Find the ID of the current-device parent by following the maximum decrease in
- * potential.
- *
- * @param potential num, potential
- * @return          num, imRoot()|noParent()|parentId
- * @see imRoot, noParent
- */
-public def getParentId(potential) {
-    getParent(potential, (device) -> { device.getDeviceUID() })
-}
-
-/**
- * Find the IDs of the current-device parents by following a potential decrease.
- *
- * @param potential num, potential
- * @return          [num], list of parent ids
- */
-public def getParentIds(potential) {
-    idUnion(getParents(potential, (device) -> { device.getDeviceUID() }, identity, NaN, NaN).get(0))
-}
-
-/**
- * @param id num, device id
- * @return   bool, true if the device has no parent
- */
-public def hasNoParent(id) {
-    id == noParent() || id == imRoot()
-}
-
-/**
- * @param id num, device id
- * @return   bool, true if the device has a parent
- */
-public def hasParent(id) {
-    !hasNoParent(id)
-}
-
-/**
- * @return num, root value
- */
-public def imRoot() { -2 }
-
-/**
- * This function MUST NOT be public as it is an utilities for both protelis:coord:accumulation and
- * protelis:coord:tree. This function reduces a field of ids
- */
-def idUnion(idField) {
-    hood(
-        (a, b) -> {
-            if (a.size() == 1 && hasNoParent(a.get(0))) { // a has no parent
-                if (hasNoParent(b.get(0))) { [] } else { b }
-            } else {
-                if (hasNoParent(b.get(0))) { a } else {  a.union(b) }
-            }
-        },
-        [],
-        [idField]
-    )
-}
-
-
-/**
- * Laplacian consensus.
- *
- * @param init    num, initial value
- * @param epsilon num, epsilon
- * @return        num, value agreed upon consensus
- */
-public def laplacianConsensus(init, epsilon) {
-     consensus(init, (v) -> {epsilon * v})
-}
-
-/**
- * @return num, error finding parent
- */
-public def noParent() { -1 }
-
-/**
- * Broadcast the value accumulated by the sink.
- * Example: 'summarize(distanceTo(sink), sum, 1, 0)' broadcast the sum number of
- * devices in a region.
- *
- * @param sink   bool, whether the device should collect the aggregated information
- * @param reduce (T, T) -> T, how to aggregate
- * @param local  T, local value
- * @param null   T, default value
- * @return       T, aggregated value
- */
-public def summarize(sink, reduce, local, null) {
-    summarizeWithMetric(sink, nbrRange, reduce, local, null)
-}
-
-/**
- * Broadcast the value accumulated by the sink.
- *
- * @param sink   bool, whether the device should collect the aggregated information
- * @param metric () -> num, how to estimate distance to the other device
- * @param reduce (T, T) -> T, how to aggregate
- * @param local  T, local value
- * @param null   T, default value
- * @return       T, aggregated value
- */
-public def summarizeWithMetric(sink, metric, accumulate, local, null) {
-    broadcastWithMetric(sink, C(distanceToWithMetric(sink, metric), accumulate, local, null), metric)
-}
-
-/**
- * Broadcast the value accumulated by the sink.
- *
- * @param potential num, potential
- * @param zero      num, value representing null potential
- * @param reduce    (T, T) -> T, how to aggregate
- * @param local     T, local value
- * @param null      T, default value
- * @return          T, aggregated value
- */
-public def summarizeWithPotential(potential, zero, accumulate, local, null) {
-    summarizeWithPotentialExt(potential, zero, accumulate, identity, local, null)
-}
-
-public def summarizeWithPotentialExt(potential, zero, accumulate, f, local, null) {
-    broadcastWithMetric(
-        potential == zero,
-        f.apply(C(potential, accumulate, local, null)),
-        () -> { potential }
-    )
-}
-
-/**
- * Quorum sensing.
- * 
- * @param potential num, gradient of which gives aggregation direction
- * @param thr       num, threshold
- * @param under     (num) -> T, what to do if quorum is under threshold
- * @param over      (num) -> T, what to do otherwise
- * @return          T
- */
-public def quorumSensing(potential, zero, thr, under, over) {
-    quorumSensingWithCondition(potential, zero, thr, true, under, over)
-}
-
-/**
- * Quorum sensing.
- * 
- * @param potential num, gradient of which gives aggregation direction
- * @param thr       num, threshold
- * @param condition bool, whether to count a device or not
- * @param under     (num) -> T, what to do if quorum is under threshold
- * @param over      (num) -> T, what to do otherwise
- * @return          T
- */
-public def quorumSensingWithCondition(potential, zero, thr, condition, under, over) {
-    let c = broadcast(potential == zero, countDevicesWithCondition(potential, condition));
-    if (c < thr) {
-        under.apply(c)
-    } else {
-        over.apply(c)
-    }
 }

--- a/src/test/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinDocTests.kt
+++ b/src/test/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinDocTests.kt
@@ -75,6 +75,7 @@ public def getParents(potential, f, g, local, default) {
 
         dependencies {
             implementation(kotlin("stdlib"))
+            implementation("org.protelis:protelis-interpreter:11.1.0")
         }
 
         repositories {

--- a/src/test/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinDocTests.kt
+++ b/src/test/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinDocTests.kt
@@ -34,6 +34,36 @@ import java.lang.Math.pow
 public def and(a, b) {
     a && b
 }
+
+/**
+ * Find the parent of the current device following the maximum decrease in
+ * potential.
+ *
+ * @param potential num, potential
+ * @param f         (ExecutionContext) -> T, what to do with the parent
+ * @param g         (T') -> T', what to do with the value
+ * @param local     T', local value
+ * @return          [num|T,T'], [imRoot()|noParent()|f(parent), g(value)]
+ * @see imRoot, noParent
+ */
+public def getParentExtended(potential, f, g, local) {
+    getParentsExtended(potential, v -> { minHood(v) }, f, g, local, local)
+}
+
+/**
+ * Find the parents of the current device following the decrease in
+ * potential.
+ *
+ * @param potential num, potential
+ * @param f         (ExecutionContext) -> T, what to do with the parent
+ * @param g         (T') -> T', what to do with the value
+ * @param local     T', local value
+ * @return          [[num|T,T']], [[imRoot()|noParent()|f(parent), g(value)]]
+ * @see imRoot, noParent
+ */
+public def getParents(potential, f, g, local, default) {
+    getParentsExtended(potential, identity, f, g, local, default)
+}
         """.trimIndent()
         )
 

--- a/src/test/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinTests.kt
+++ b/src/test/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinTests.kt
@@ -48,6 +48,7 @@ public def and(a, b) {
 
         dependencies {
             implementation(kotlin("stdlib"))
+            implementation("org.protelis:protelis-interpreter:11.1.0")
         }
 
         repositories {


### PR DESCRIPTION
This set of changes handles the following:

- Protelis types appearing in docs, e.g., `ExecutionContext`, which need to be imported
- Tuple types