### PR TITLE
Disable automatic resolution of dependencies by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build
 out
 
 .kotlintest
+
+.java-version

--- a/README.md
+++ b/README.md
@@ -32,8 +32,17 @@ Protelis2KotlinDoc {
   kotlinVersion.set("+")
   protelisVersion.set("+")
   outputFormat.set("javadoc") // Dokka's output format (alternative: 'html')
-  automaticDependencies.set(true) // Automatic resolution of deps (e.g., protelis-interpreter)
+  automaticDependencies.set(false) // Automatic resolution of deps (e.g., protelis-interpreter)
   debug.set(false) // Debug prints are disabled by default
+}
+```
+
+Note: when automatic resolution of dependencies is disabled (default), you should add the following dependencies for the plugin to work:
+
+```kotlin
+dependencies {
+    implementation("org.protelis:protelis-interpreter:11.1.0")
+    implementation(kotlin("stdlib"))
 }
 ```
 

--- a/src/main/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinDocPlugin.kt
+++ b/src/main/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinDocPlugin.kt
@@ -21,7 +21,7 @@ open class Protelis2KotlinDocPluginExtension @JvmOverloads constructor(
     val kotlinVersion: Property<String> = project.propertyWithDefault("+"),
     val protelisVersion: Property<String> = project.propertyWithDefault("+"),
     val outputFormat: Property<String> = project.propertyWithDefault("javadoc"),
-    val automaticDependencies: Property<Boolean> = project.propertyWithDefault(true),
+    val automaticDependencies: Property<Boolean> = project.propertyWithDefault(false),
     val debug: Property<Boolean> = project.propertyWithDefault(false)
 )
 

--- a/src/test/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinDocTests.kt
+++ b/src/test/kotlin/it/unibo/protelis2kotlin/Protelis2KotlinDocTests.kt
@@ -93,8 +93,12 @@ public def aggregation(local, reduce) {
 
         file("build.gradle.kts") { """
         plugins {
-            // kotlin("jvm") version "1.3.21"
             id("it.unibo.protelis2kotlindoc")
+        }
+
+        dependencies {
+            implementation("org.protelis:protelis-interpreter:11.1.0")
+            implementation(kotlin("stdlib"))
         }
 
         // repositories {


### PR DESCRIPTION
Quick fix to #15 

- disabling automatic resolution of dependencies by default
- updating documentation for this (explicit specification of dependencies: `kotlin-stdlib` and `protelis-lang`)