### PR TITLE
Upgrade org.jetbrains.dokka from 0.9.18 to 0.10.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -11,8 +11,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 plugin.org.danilopianini.publish-on-central=0.1.1
 ##                              # available=0.2.3
 
-plugin.org.jetbrains.dokka=0.9.18
-##             # available=0.10.1
+plugin.org.jetbrains.dokka=0.10.1
 
 plugin.org.jlleitschuh.gradle.ktlint=8.0.0
 ##                       # available=9.2.1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.