### PR TITLE
Upgrade kotlintest from 3.3.2 to 3.4.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -20,8 +20,7 @@ plugin.org.jlleitschuh.gradle.ktlint=8.0.0
 version.kotlin=1.3.31
 ## # available=1.3.71
 
-version.kotlintest=3.3.2
-##     # available=3.4.2
+version.kotlintest=3.4.2
 
 version.org.jetbrains.dokka..dokka-gradle-plugin=0.9.18
 ##                                   # available=0.10.1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.