### PR TITLE
Upgrade dokka from 0.10.1 to 0.11.0-dev-59

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,7 +10,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
 plugin.org.danilopianini.publish-on-central=0.2.3
 
-plugin.org.jetbrains.dokka=0.10.1
+plugin.org.jetbrains.dokka=0.11.0-dev-59
 
 plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.