### PR TITLE
Upgrade dokka from 1.4.32 to 1.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,7 +15,7 @@ plugin.org.jetbrains.dokka=version.org.jetbrains.dokka..dokka-gradle-plugin
 
 plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
-version.dokka=1.4.32
+version.dokka=1.5.0
 
 version.io.kotlintest..kotlintest-runner-junit5=3.4.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.